### PR TITLE
Fix typo in macro.

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -193,7 +193,7 @@
 //!        the condition is not met
 //! \param[in] assertion The condition being tested.
 //! \param[in] message The message to be printed if the condition is false
-#define assert_info(assertioan, message, ...)                           \
+#define assert_info(assertion, message, ...)                            \
     do {                                                                \
         if (!(assertion)) {                                             \
             __log(LOG_DEBUG, "[ASSERT]   ", message, ##__VA_ARGS__);    \


### PR DESCRIPTION
Fortunately, the macro is unused, but the speelign eror is strong with this one.