### PR TITLE
Add sqrt.h to HEADERS list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ OBJS = bit_field.o circular_buffer.o normal.o random.o stdfix-exp.o log.o sincos
 BUILD_OBJS = $(OBJS:%.o=$(SPINN_COMMON_BUILD)/%.o)
 
 # Headers
-HEADERS = arm_acle_gcc.h arm_acle.h arm.h bit_field.h circular_buffer.h cmsis.h core_v5te.h debug.h log.h normal.h pair.h polynomial.h random.h sincos.h spin-print.h static-assert.h stdfix-exp.h stdfix-full-iso.h utils.h
+HEADERS = arm_acle_gcc.h arm_acle.h arm.h bit_field.h circular_buffer.h cmsis.h core_v5te.h debug.h log.h normal.h pair.h polynomial.h random.h sincos.h spin-print.h sqrt.h static-assert.h stdfix-exp.h stdfix-full-iso.h utils.h
 INSTALL_HEADERS = $(HEADERS:%.h=$(SPINN_INC_DIR)/%.h)
 
 # Build rules (default)


### PR DESCRIPTION
- not technically a bug, but it should be copied over to
spinnaker_tools when "make install" is used here.  Guessing that
we haven't noticed this because no-one actually uses sqrt anywhere
right now...

Fix of https://github.com/SpiNNakerManchester/SpiNNakerManchester.github.io/issues/11