### PR TITLE
Add building of the code to the test schedule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,21 @@ language: c
 
 addons:
   apt:
+    sources:
+      - sourceline: 'deb http://us.archive.ubuntu.com/ubuntu/ trusty universe'
     packages:
       - vera++
-      #- gcc-arm-none-eabi
-      #- libnewlib-arm-none-eabi
+      - gcc-arm-none-eabi
+      - libnewlib-arm-none-eabi
 
 install:
   - git clone https://github.com/SpiNNakerManchester/SupportScripts.git support
-# TODO: Add actually building the code
+  - git clone https://github.com/SpiNNakerManchester/spinnaker_tools.git tools
+  - export SPINN_DIRS=`pwd`/tools GNU=1
+  - make -C tools/sark
+  - make -C tools/spin1_api
 
 script:
+  - make
   - support/run-vera.sh include -P max-file-length=2500
   - support/run-vera.sh src


### PR DESCRIPTION
This adds building of the `spinn_common` code to the automatic test schedule. _Depends_ on being able to build `spinnaker_tools`; specifically sark and spin1_api.