### PR TITLE
Emergency fix for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ install:
 
 script:
   - make
+  - make install
   - support/run-vera.sh include -P max-file-length=2500
   - support/run-vera.sh src

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ $(SPINN_COMMON_BUILD):
 # Installing rules
 install: $(SPINN_COMMON_BUILD)/libspinn_common.a
 	$(INSTALL) -c -m644 $< $(SPINN_LIB_DIR)
-	$(INSTALL) -c -m644 $(HEADERS) $(SPINN_INC_DIR)
+	$(INSTALL) -c -m644 $(HEADERS:%.h=include/%.h) $(SPINN_INC_DIR)
 
 clean:
 	$(RM) $(SPINN_COMMON_BUILD)/libspinn_common.a $(BUILD_OBJS)


### PR DESCRIPTION
Ensure that installation is tested as well as compilation. Also make sure that installation of headers goes from the right directory!