### PR TITLE
Add an operation to count the number of set bits in a bitfield

### DIFF
--- a/include/bit_field.h
+++ b/include/bit_field.h
@@ -236,6 +236,22 @@ static inline size_t get_bit_field_size(
     return words;
 }
 
+//! \brief Computes the number of set bits in a bit_field
+//! \param[in] b The sequence of words representing a bit_field.
+//! \param[in] s The size of the bit_field.
+//! \return The function returns the number of bits set to 1.
+static inline int count_bit_field(
+	bit_field_t b,
+	size_t s)
+{
+    int sum = 0;
+
+    for ( ; s > 0; s--) {
+	sum += __builtin_popcount(b[s - 1]);
+    }
+    return sum;
+}
+
 //! \brief Prints a bit_field as ones and zeros.
 //! \param[in] b The sequence of words representing a bit_field.
 //! \param[in] s The size of the bit_field.


### PR DESCRIPTION
This is an implementation of the count-all-the-set-bits operation that @alan-stokes needs for his field compression work.

It's implemented as a `static inline` function so it will only impose a cost on code files that actually need the functionality (and that's acceptable). The core of the magic is GCC's [`__builtin_popcount()`](https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html), which is defined as:

> Built-in Function: _int_ **__builtin_popcount** (_unsigned int x_)
> &nbsp; &nbsp; &nbsp; &nbsp; Returns the number of 1-bits in _x_.

Perfect for this use!