### PR TITLE
Tighten up the circular buffer code

### DIFF
--- a/include/circular_buffer.h
+++ b/include/circular_buffer.h
@@ -5,11 +5,11 @@
 #include <stdbool.h>
 
 typedef struct _circular_buffer {
-    uint32_t* buffer;
     uint32_t buffer_size;
     uint32_t output;
     uint32_t input;
     uint32_t overflows;
+    uint32_t buffer[];
 } _circular_buffer, *circular_buffer;
 
 // Returns the index of the next position in the buffer from the given value
@@ -31,7 +31,7 @@ static inline bool _circular_buffer_not_empty(
 static inline bool _circular_buffer_not_full(
 	circular_buffer buffer)
 {
-    return ((buffer->input + 1) & buffer->buffer_size) != buffer->output;
+    return _circular_buffer_next(buffer, buffer->input) != buffer->output;
 }
 
 //! \brief Creates a new FIFO circular buffer of at least the given size.  For

--- a/src/circular_buffer.c
+++ b/src/circular_buffer.c
@@ -46,13 +46,9 @@ circular_buffer circular_buffer_initialize(
 	real_size = next_power_of_2(size);
     }
 
-    circular_buffer buffer = sark_alloc(1, sizeof(_circular_buffer));
+    circular_buffer buffer = sark_alloc(1,
+	    sizeof(_circular_buffer) + real_size * sizeof(uint32_t));
     if (buffer == NULL) {
-	return NULL;
-    }
-
-    buffer->buffer = sark_alloc(1, real_size * sizeof(uint32_t));
-    if (buffer->buffer == NULL) {
 	return NULL;
     }
 


### PR DESCRIPTION
We don't need to allocate the actual buffer separately; putting it immediately after the metadata works just as well and saves both ITCM and DTCM space.