### PR TITLE
Upgrade to Xenial (gcc 4.9, etc) and colorize the output of gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: c
 
 addons:
@@ -18,7 +18,7 @@ install:
   - make -C spinnaker_tools/spin1_api
 
 script:
-  - make
+  - CFLAGS=-fdiagnostics-color make
   - make install
   - support/run-vera.sh include -P max-file-length=2500
   - support/run-vera.sh src


### PR DESCRIPTION
We need this anyway to get full ISO C11 support.