### PR TITLE
Poisson multiplier speedup

### DIFF
--- a/include/stdfix-full-iso.h
+++ b/include/stdfix-full-iso.h
@@ -1183,7 +1183,7 @@ static inline uint32_t __stdfix_smul_ulr(
 	uint32_t x,
 	uint32_t y)
 {
-    return ((__U64(x) * __U64(y)) >> 32);
+    return __stdfix_sat_ulr((__U64(x) * __U64(y)) >> 32);
 }
 
 //! \brief Saturated multiplicaion of the underlying unsigned integer representations

--- a/include/stdfix-full-iso.h
+++ b/include/stdfix-full-iso.h
@@ -1183,7 +1183,7 @@ static inline uint32_t __stdfix_smul_ulr(
 	uint32_t x,
 	uint32_t y)
 {
-    return __stdfix_sat_ulr((__U64(x) * __U64(y)) >> 32);
+    return ((__U64(x) * __U64(y)) >> 32);
 }
 
 //! \brief Saturated multiplicaion of the underlying unsigned integer representations

--- a/src/random.c
+++ b/src/random.c
@@ -402,7 +402,9 @@ uint32_t poisson_dist_variate_exp_minus_lambda(
 
     do {
 	k++;
-	p = p * ulrbits(uni_rng(seed_arg));
+//	p = p * ulrbits(uni_rng(seed_arg));
+    // Possibly faster multiplication by using DRL's routines
+    p = ulrbits(__stdfix_smul_ulr(bitsulr(p), uni_rng(seed_arg)));
     } while (p > exp_minus_lambda);
     return k - 1;
 }

--- a/src/random.c
+++ b/src/random.c
@@ -401,10 +401,10 @@ uint32_t poisson_dist_variate_exp_minus_lambda(
     //!     return k;
 
     do {
-	k++;
-//	p = p * ulrbits(uni_rng(seed_arg));
-    // Possibly faster multiplication by using DRL's routines
-    p = ulrbits(__stdfix_smul_ulr(bitsulr(p), uni_rng(seed_arg)));
+    	k++;
+    	//	p = p * ulrbits(uni_rng(seed_arg));
+    	// Possibly faster multiplication by using DRL's routines
+    	p = ulrbits(__stdfix_smul_ulr(bitsulr(p), uni_rng(seed_arg)));
     } while (p > exp_minus_lambda);
     return k - 1;
 }


### PR DESCRIPTION
This should speedup the poisson generator as GCC ULRxULR multipliers are known to be slow.