### PR TITLE
Generate a .tag file and cross-link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /.cproject
 /html/
 *.bak
+*.tag

--- a/.ratexcludes
+++ b/.ratexcludes
@@ -1,2 +1,3 @@
 **/spinnaker_tools/**
 **/.nojekyll
+**/*.tag

--- a/.sllt_template.tag
+++ b/.sllt_template.tag
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<tagfile>
+  <compound kind="page">
+    <name>index</name>
+    <title>spinnaker_tools: SpiNNaker API, SARK, SC&amp;MP, and Spin1 API</title>
+    <filename>index.html</filename>
+  </compound>
+</tagfile>

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ before_install:
   - git clone https://github.com/SpiNNakerManchester/SupportScripts.git support
   - python support/travis_blocking_stdout.py
   - support/rat.sh download
+  - export SPINN_DIRS=`pwd`/spinnaker_tools GNU=1
+  - make sllt.tag
 
 install:
   - support/gitclone.sh https://github.com/SpiNNakerManchester/spinnaker_tools.git
-  - export SPINN_DIRS=`pwd`/spinnaker_tools GNU=1
   - make -C spinnaker_tools/sark
   - make -C spinnaker_tools/spin1_api
 
@@ -50,7 +51,7 @@ script:
   # Copyright check
   - support/rat.sh run
   # Documentation build
-  - doxygen
+  - make doxygen
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ before_install:
   - python support/travis_blocking_stdout.py
   - support/rat.sh download
   - export SPINN_DIRS=`pwd`/spinnaker_tools GNU=1
-  - make sllt.tag
 
 install:
   - support/gitclone.sh https://github.com/SpiNNakerManchester/spinnaker_tools.git
   - make -C spinnaker_tools/sark
   - make -C spinnaker_tools/spin1_api
+  - make sllt.tag
 
 script:
   - CFLAGS=-fdiagnostics-color make

--- a/Doxyfile
+++ b/Doxyfile
@@ -1634,13 +1634,13 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = sllt.tag=http://spinnakermanchester.github.io/spinnaker_tools/ 
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = html/common.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,13 @@ HEADERS = arm_acle_gcc.h arm_acle.h arm.h assert.h bit_field.h \
 	stdfix-full-iso.h utils.h round.h
 INSTALL_HEADERS = $(HEADERS:%.h=$(SPINN_INC_DIR)/%.h)
 
+# Locations of tag files
+TAGFILES=sllt.tag
+SLLT_TAG=http://spinnakermanchester.github.io/spinnaker_tools/sllt.tag
+
 INSTALL ?= install
+DOXYGEN ?= doxygen
+WGET ?= wget
 
 $(SPINN_COMMON_BUILD)/%.o: src/%.c $(SPINN_COMMON_BUILD)
 	$(CC) $(CFLAGS) -o $@ $<
@@ -63,8 +69,18 @@ install: $(SPINN_COMMON_BUILD)/libspinn_common.a
 clean:
 	$(RM) $(SPINN_COMMON_BUILD)/libspinn_common.a $(BUILD_OBJS) \
 	$(SPINN_LIB_DIR)/*.dict $(SPINN_LIB_DIR)/*.ranges $(INSTALL_HEADERS)
+	-$(RM) $(TAGFILES)
 
 install-clean:
 	$(RM) $(INSTALL_HEADERS)
 
-.PHONY: all install clean install-clean
+sllt.tag: .sllt_template.tag
+	cp .sllt_template.tag sllt.tag
+ifneq (, $(shell which $(WGET)))
+	-$(WGET) -q -O sllt.tag $(SLLT_TAG)
+endif 
+
+doxygen: $(TAGFILES)
+	$(DOXYGEN)
+
+.PHONY: all install clean install-clean doxygen


### PR DESCRIPTION
Will use the tag file from `spinnaker_tools` if it can get it. Have tested that locally. Being unable to get the dependency tag file is non-fatal as there's a fallback.