### PR TITLE
Unused marker rewrite

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1596,7 +1596,8 @@ PREDEFINED             = DOXYGEN=1 \
                          __arm__ \
                          __GNUC__ \
                          __ARM_ARCH_5TE__ \
-                         __ARM_FEATURE_DSP
+                         __ARM_FEATURE_DSP \
+                         UNUSED=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -1634,7 +1635,7 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = sllt.tag=http://spinnakermanchester.github.io/spinnaker_tools/ 
+TAGFILES               = sllt.tag=http://spinnakermanchester.github.io/spinnaker_tools/
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/include/arm_acle_gcc.h
+++ b/include/arm_acle_gcc.h
@@ -64,8 +64,8 @@ static_assert(false,
 	"Attempt to compile arm_acle_gcc.h for non-arm architecture");
 #endif
 
-#ifndef use
-#define use(x)      do {} while ((x)!=(x))
+#ifndef UNUSED
+#define UNUSED      __attribute__((__unused__))
 #endif
 
 // Following are all pre-defined at this stage, either above, or by GCC
@@ -553,9 +553,8 @@ static inline void __yield(void)
 //! This function implements the ARM dbg instruction.
 
 static inline void __dbg(
-	/*constant*/ unsigned int n)
+        UNUSED /*constant*/ unsigned int n)
 {
-    use(n);
     __ARM_ACLE_nop();
 }
 

--- a/include/bit_field.h
+++ b/include/bit_field.h
@@ -68,15 +68,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-//! \brief The use macro allows us to "pretend" to use a variable in a
-//!     function; this is useful if we run with -Wextra set for extra
-//!     warnings.
-//! \note This macro would be unsafe with floating point arguments
-
-#ifndef use
-#define use(x)		do {} while ((x)!=(x))
-#endif
-
 //! \brief bit_field_t is an arbitrary length bit field (vector of bits)
 //!     which is used to compactly represent a large number of boolean
 //!     operations.
@@ -139,7 +130,7 @@ static inline void not_bit_field(
 	size_t s)
 {
     for ( ; s > 0; s--) {
-	b[s-1] = ~ b[s-1];
+        b[s-1] = ~ b[s-1];
     }
 }
 
@@ -154,7 +145,7 @@ static inline void and_bit_fields(
 	size_t s)
 {
     for ( ; s > 0; s--) {
-	b1[s-1] &= b2[s-1];
+        b1[s-1] &= b2[s-1];
     }
 }
 
@@ -169,7 +160,7 @@ static inline void or_bit_fields(
 	size_t s)
 {
     for ( ; s > 0; s--) {
-	b1[s-1] |= b2[s-1];
+        b1[s-1] |= b2[s-1];
     }
 }
 
@@ -181,7 +172,7 @@ static inline void clear_bit_field(
 	size_t s)
 {
     for ( ; s > 0; s--) {
-	b[s-1] = 0;
+        b[s-1] = 0;
     }
 }
 
@@ -193,7 +184,7 @@ static inline void set_bit_field(
 	size_t s)
 {
     for ( ; s > 0; s--) {
-	b[s-1] = 0xFFFFFFFF;
+        b[s-1] = 0xFFFFFFFF;
     }
 }
 
@@ -215,8 +206,8 @@ static inline bool empty_bit_field(
 
 //! \brief Testing whether a bit_field is non-empty, _i.e._ if there is at
 //!     least one bit set.
-//! \param[in] b The sequence of words representing a bit_field.
-//! \param[in] s The size of the bit_field.
+//! \param[in] b: The sequence of words representing a bit_field.
+//! \param[in] s: The size of the bit_field.
 //! \return The function returns true if at least one bit is set; otherwise false.
 static inline bool nonempty_bit_field(
 	const bit_field_t restrict b,
@@ -227,7 +218,7 @@ static inline bool nonempty_bit_field(
 
 //! \brief A function that calculates the size of a bit_field to hold 'bits'
 //!     bits.
-//! \param[in] bits The number of bits required for this bit_field.
+//! \param[in] bits: The number of bits required for this bit_field.
 //! \return The size (or number of words) in the bit_field.
 static inline size_t get_bit_field_size(
 	size_t bits)
@@ -247,8 +238,8 @@ static inline size_t get_bit_field_size(
 }
 
 //! \brief Computes the number of set bits in a bit_field
-//! \param[in] b The sequence of words representing a bit_field.
-//! \param[in] s The size of the bit_field.
+//! \param[in] b: The sequence of words representing a bit_field.
+//! \param[in] s: The size of the bit_field.
 //! \return The function returns the number of bits set to 1.
 static inline int count_bit_field(
 	const bit_field_t restrict b,
@@ -257,7 +248,7 @@ static inline int count_bit_field(
     int sum = 0;
 
     for ( ; s > 0; s--) {
-	sum += __builtin_popcount(b[s - 1]);
+        sum += __builtin_popcount(b[s - 1]);
     }
     return sum;
 }

--- a/src/bit_field.c
+++ b/src/bit_field.c
@@ -65,17 +65,24 @@
 #include "bit_field.h"
 #include "sark.h"
 
+//! \brief The use macro allows us to "pretend" to use a variable in a
+//!     function; this is useful if we run with -Wextra set for extra
+//!     warnings.
+//! \param x: The name of the argument to mark as used
+
+#ifndef __use
+#define __use(x)      ((void) (x))
+#endif
+
 //! \brief This function prints out an individual word of a bit_field,
 //!     as a sequence of ones and zeros.
 //! \param[in] e The word of a bit_field to be printed.
 static inline void print_bit_field_entry(
         uint32_t e)
 {
-    counter_t i = 32;
-
-    for ( ; i > 0; i--) {
-	io_printf(IO_BUF, "%c", ((e & 0x1) == 0) ? ' ' : '1');
-	e >>= 1;
+    for (counter_t i = 32 ; i > 0; i--) {
+        io_printf(IO_BUF, "%c", ((e & 0x1) == 0) ? ' ' : '1');
+        e >>= 1;
     }
 
     io_printf(IO_BUF, "\n");
@@ -85,13 +92,11 @@ void print_bit_field_bits(
         const bit_field_t restrict b,
         size_t s)
 {
-    use(b);
-    use(s);
+    __use(b);
+    __use(s);
 #if LOG_LEVEL >= LOG_DEBUG
-    index_t i; // For indexing through the bit field
-
-    for (i = 0; i < s; i++) {
-	print_bit_field_entry(b[i]);
+    for (index_t i = 0; i < s; i++) {
+        print_bit_field_entry(b[i]);
     }
 #endif // LOG_LEVEL >= LOG_DEBUG
 }
@@ -100,13 +105,11 @@ void print_bit_field(
         const bit_field_t restrict b,
         size_t s)
 {
-    use(b);
-    use(s);
+    __use(b);
+    __use(s);
 #if LOG_LEVEL >= LOG_DEBUG
-    index_t i; // For indexing through the bit field
-
-    for (i = 0; i < s; i++) {
-	    io_printf(IO_BUF, "%08x\n", b[i]);
+    for (index_t i = 0; i < s; i++) {
+        io_printf(IO_BUF, "%08x\n", b[i]);
     }
 #endif // LOG_LEVEL >= LOG_DEBUG
 }
@@ -115,13 +118,11 @@ void random_bit_field(
         bit_field_t restrict b,
         size_t s)
 {
-    use(b);
-    use(s);
+    __use(b);
+    __use(s);
 #if LOG_LEVEL >= LOG_DEBUG
-    index_t i; // For indexing through the bit field
-
-    for (i = 0; i < s; i++) {
-	b[i] = sark_rand();
+    for (index_t i = 0; i < s; i++) {
+        b[i] = sark_rand();
     }
 #endif // LOG_LEVEL >= LOG_DEBUG
 }


### PR DESCRIPTION
Both gcc and armcc support `__attribute__((unused))` on parameter declarations, and that has the advantage of resulting in a warning if it is inadvertently used. I map it to `UNUSED` (hidden from doxygen) for convenience. I also change `use(x)` — still needed in a few places where deciding if something is used is tricky — to `((void)(x))` as that's the conventional and hazard-free way of marking a variable as used.