### PR TITLE
Move to GitHub Actions

### DIFF
--- a/.github/workflows/c_actions.yml
+++ b/.github/workflows/c_actions.yml
@@ -42,6 +42,7 @@ jobs:
         
     - name: Set SPINN_DIRS
       run: |
+        echo "Set SPINN_DIRS to $PWD/spinnaker_tools"
         echo "SPINN_DIRS=$PWD/spinnaker_tools" >> $GITHUB_ENV
         
     - name: Checkout SpiNNaker Dependencies

--- a/.github/workflows/c_actions.yml
+++ b/.github/workflows/c_actions.yml
@@ -1,0 +1,79 @@
+# Copyright (c) 2020 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This workflow will install Python dependencies, run tests, lint and rat with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: C Actions
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Checkout SupportScripts
+      uses: actions/checkout@v2
+      with:
+        repository: SpiNNakerManchester/SupportScripts
+        path: support
+        
+    - name: Set GITHUB_BRANCH
+      # This step can not be merged with Checkout Spinnaker Dependencies
+      run: |
+        echo "GITHUB_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+        
+    - name: Set SPINN_DIRS
+      run: |
+        echo "SPINN_DIRS=$PWD" >> $GITHUB_ENV
+        
+    - name: Checkout SpiNNaker Dependencies
+      run: support/gitclone2.sh https://github.com/SpiNNakerManchester/spinnaker_tools.git
+        
+    - name: Install arm-none-eabi-gcc
+      uses: fiam/arm-none-eabi-gcc@v1.0.2
+      with:
+        release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
+            
+    - name: Install vera++, doxygen and openjdk
+      run: sudo apt-get update && sudo apt-get install vera++ doxygen freeglut3-dev openjdk-8-jre-headless --fix-missing
+    
+    - name: Build C code
+      run: |
+        make -C spinnaker_tools/sark
+        make -C spinnaker_tools/spin1_api
+        make sllt.tag
+        CFLAGS=-fdiagnostics-color make
+        make install
+        
+    - name: Lint C code using Vera++
+      run: |
+        support/run-vera.sh include -P max-line-length=2500
+        support/run-vera.sh src
+        
+    - name: Run rat copyright enforcement
+      run: |
+        support/rat.sh download
+        support/rat.sh run
+       
+    - name: Build documentation using doxygen
+      run: |
+        make doxygen
+        

--- a/.github/workflows/c_actions.yml
+++ b/.github/workflows/c_actions.yml
@@ -22,10 +22,13 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
+    - name: Condition the VM
+      run: |
+        sudo apt-get update
+    
     - name: Checkout
       uses: actions/checkout@v2
 
@@ -34,47 +37,49 @@ jobs:
       with:
         repository: SpiNNakerManchester/SupportScripts
         path: support
-        
-    - name: Set GITHUB_BRANCH
+
+    - name: Set dynamic environment variables
       # This step can not be merged with Checkout Spinnaker Dependencies
-      run: |
-        echo "GITHUB_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-        
-    - name: Set SPINN_DIRS
       run: |
         echo "Set SPINN_DIRS to $PWD/spinnaker_tools"
         echo "SPINN_DIRS=$PWD/spinnaker_tools" >> $GITHUB_ENV
-        
+        echo "GITHUB_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+
     - name: Checkout SpiNNaker Dependencies
       run: support/gitclone2.sh https://github.com/SpiNNakerManchester/spinnaker_tools.git
-        
+
     - name: Install arm-none-eabi-gcc
       uses: fiam/arm-none-eabi-gcc@v1.0.2
       with:
         release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
-            
-    - name: Install vera++, doxygen and openjdk
-      run: sudo apt-get update && sudo apt-get install vera++ doxygen openjdk-8-jre-headless --fix-missing
-    
-    - name: Build C code
+
+    - name: Install misc tooling dependencies
+      run: |
+        sudo apt-get install vera++ doxygen openjdk-8-jre-headless --fix-missing
+
+    - name: Build dependency libraries
       run: |
         make -C spinnaker_tools/sark
         make -C spinnaker_tools/spin1_api
         make sllt.tag
+
+    - name: Build C code
+      run: |
         CFLAGS=-fdiagnostics-color make
         make install
-        
+      env:
+        GCC_COLORS: error=01;31:warning=01;35:note=01;36:range1=32:range2=34:locus=01:quote=01:fixit-insert=32:fixit-delete=31:diff-filename=01:diff-hunk=32:diff-delete=31:diff-insert=32" >> $GITHUB_ENV
+
     - name: Lint C code using Vera++
       run: |
         support/run-vera.sh include -P max-line-length=2500
         support/run-vera.sh src
-        
+
     - name: Run rat copyright enforcement
       run: |
         support/rat.sh download
         support/rat.sh run
-       
+
     - name: Build documentation using doxygen
       run: |
         make doxygen
-        

--- a/.github/workflows/c_actions.yml
+++ b/.github/workflows/c_actions.yml
@@ -54,7 +54,7 @@ jobs:
         release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
             
     - name: Install vera++, doxygen and openjdk
-      run: sudo apt-get update && sudo apt-get install vera++ doxygen freeglut3-dev openjdk-8-jre-headless --fix-missing
+      run: sudo apt-get update && sudo apt-get install vera++ doxygen openjdk-8-jre-headless --fix-missing
     
     - name: Build C code
       run: |

--- a/.github/workflows/c_actions.yml
+++ b/.github/workflows/c_actions.yml
@@ -42,7 +42,7 @@ jobs:
         
     - name: Set SPINN_DIRS
       run: |
-        echo "SPINN_DIRS=$PWD" >> $GITHUB_ENV
+        echo "SPINN_DIRS=$PWD/spinnaker_tools" >> $GITHUB_ENV
         
     - name: Checkout SpiNNaker Dependencies
       run: support/gitclone2.sh https://github.com/SpiNNakerManchester/spinnaker_tools.git


### PR DESCRIPTION
As with https://github.com/SpiNNakerManchester/spinnaker_tools/pull/145 (though not dependent on it), moving from Travis to GitHub Actions.  Similar to that PR, deployment actions should be considered separately.