### PR TITLE
GITHUB_BRANCH is no longer needed

### DIFF
--- a/.github/workflows/c_actions.yml
+++ b/.github/workflows/c_actions.yml
@@ -43,7 +43,6 @@ jobs:
       run: |
         echo "Set SPINN_DIRS to $PWD/spinnaker_tools"
         echo "SPINN_DIRS=$PWD/spinnaker_tools" >> $GITHUB_ENV
-        echo "GITHUB_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
 
     - name: Checkout SpiNNaker Dependencies
       run: support/gitclone2.sh https://github.com/SpiNNakerManchester/spinnaker_tools.git


### PR DESCRIPTION
GITHUB_BRANCH is no longer used by the gitclone script, so removing it.